### PR TITLE
use Fortran standard subroutine "close" to delete "stop" file

### DIFF
--- a/source/cfl3d/dist/main.F
+++ b/source/cfl3d/dist/main.F
@@ -547,8 +547,8 @@ c
 c
 c     remove the stop file if there is one 
 c
-      sysfile = 'rm -f stop'
-      call system(sysfile)
+      open(unit=1234,iostat=istat1,file='stop',status='old')
+      if (istat1 == 0) close(1234, status='delete')
 c
 c***********************************************************************
 c     determine array size requirements


### PR DESCRIPTION
use Fortran standard subroutine "close" to delete "stop" file. the old style
call shell to delete file may cause problem in some OS(such as Windows).