### PR TITLE
Update readkey.F

### DIFF
--- a/source/cfl3d/libs/readkey.F
+++ b/source/cfl3d/libs/readkey.F
@@ -620,6 +620,11 @@ c
 c     dcmdd to be used for trim
       dcmdd    =-0.88
       nkey     = nkey + 1
+c     Set trim data
+      tp(1,1) = dclda
+      tp(1,2) = dcldd
+      tp(2,1) = dcmda
+      tp(2,2) = dcmdd
 c
 c     Parameter controling dynamic grid input
       ndgrd    = 0


### PR DESCRIPTION
If the keyword does not exist in the cfl3d.inp file, the variable tp will not be initialized or will be initialized to zero(Different compilers and compilation parameters behave differently.). This may lead to a division by zero error when executing the code "dtr = tp(1,1)*tp(2,2)-tp(1,2)*tp(2,1)" in init_trim.F.